### PR TITLE
docs(lightning): re-work logical 'pre-ldk' separations to simply be 'case studies'

### DIFF
--- a/bolt.fun/pages/01_guide/04_architecture/04_pre_ldk/00_introduction.md
+++ b/bolt.fun/pages/01_guide/04_architecture/04_pre_ldk/00_introduction.md
@@ -1,15 +1,15 @@
 ---
 layout: guide
-title: Pre-LDK Architectures
+title: Architecture Examples
 parent: Architecture
-description: Pre-LDK Lightning App Architectures
+description: Lightning App Architecture Examples
 nav_order: 144
 has_children: true
-permalink: /guide/architecture/pre-ldk
+permalink: /guide/architecture/examples
 main_classes: -no-top-padding
 ---
 
-# Pre-LDK Mobile App Architectures
+# Mobile App Architecture Examples
 
 **_(Incomplete)_**
 

--- a/bolt.fun/pages/01_guide/04_architecture/04_pre_ldk/00_introduction.md
+++ b/bolt.fun/pages/01_guide/04_architecture/04_pre_ldk/00_introduction.md
@@ -1,15 +1,15 @@
 ---
 layout: guide
-title: Architecture Examples
+title: Mobile App Case Studies
 parent: Architecture
-description: Lightning App Architecture Examples
+description: Lightning App Architecture Case Studies
 nav_order: 144
 has_children: true
-permalink: /guide/architecture/examples
+permalink: /guide/architecture/case-studies
 main_classes: -no-top-padding
 ---
 
-# Mobile App Architecture Examples
+# Mobile App Case Studies
 
 **_(Incomplete)_**
 

--- a/bolt.fun/pages/01_guide/04_architecture/04_pre_ldk/01_breez.md
+++ b/bolt.fun/pages/01_guide/04_architecture/04_pre_ldk/01_breez.md
@@ -1,12 +1,12 @@
 ---
 layout: guide
 title: Breez
-parent: Architecture Examples
+parent: Mobile App Case Studies
 grand_parent: Architecture
 description: Breez
 nav_order: 1
 has_children: false
-permalink: /guide/architecture/examples/breez
+permalink: /guide/architecture/case-studies/breez
 main_classes: -no-top-padding
 ---
 

--- a/bolt.fun/pages/01_guide/04_architecture/04_pre_ldk/01_breez.md
+++ b/bolt.fun/pages/01_guide/04_architecture/04_pre_ldk/01_breez.md
@@ -1,16 +1,16 @@
 ---
 layout: guide
 title: Breez
-parent: Pre-LDK Architectures
+parent: Architecture Examples
 grand_parent: Architecture
 description: Breez
 nav_order: 1
 has_children: false
-permalink: /guide/architecture/pre-ldk/breez
+permalink: /guide/architecture/examples/breez
 main_classes: -no-top-padding
 ---
 
-{% include picture.html	
+{% include picture.html
    image = "/assets/images/architecture-breez.jpg"
    retina = "/assets/images/architecture-breez@2x.jpg"
    mobile = "/assets/images/architecture-breez.jpg"

--- a/bolt.fun/pages/01_guide/04_architecture/04_pre_ldk/02_muun.md
+++ b/bolt.fun/pages/01_guide/04_architecture/04_pre_ldk/02_muun.md
@@ -1,16 +1,16 @@
 ---
 layout: guide
 title: Muun
-parent: Pre-LDK Architectures
+parent: Architecture Examples
 grand_parent: Architecture
 description: Muun
 nav_order: 2
 has_children: false
-permalink: /guide/architecture/pre-ldk/muun
+permalink: /guide/architecture/examples/muun
 main_classes: -no-top-padding
 ---
 
-{% include picture.html	
+{% include picture.html
    image = "/assets/images/architecture-muun.jpg"
    retina = "/assets/images/architecture-muun@2x.jpg"
    mobile = "/assets/images/architecture-muun.jpg"

--- a/bolt.fun/pages/01_guide/04_architecture/04_pre_ldk/02_muun.md
+++ b/bolt.fun/pages/01_guide/04_architecture/04_pre_ldk/02_muun.md
@@ -1,12 +1,12 @@
 ---
 layout: guide
 title: Muun
-parent: Architecture Examples
+parent: Mobile App Case Studies
 grand_parent: Architecture
 description: Muun
 nav_order: 2
 has_children: false
-permalink: /guide/architecture/examples/muun
+permalink: /guide/architecture/case-studies/muun
 main_classes: -no-top-padding
 ---
 

--- a/bolt.fun/pages/01_guide/04_architecture/04_pre_ldk/03_phoenix.md
+++ b/bolt.fun/pages/01_guide/04_architecture/04_pre_ldk/03_phoenix.md
@@ -1,16 +1,16 @@
 ---
 layout: guide
 title: Phoenix
-parent: Pre-LDK Architectures
+parent: Architecture Examples
 grand_parent: Architecture
 description: Phoenix
 nav_order: 3
 has_children: false
-permalink: /guide/architecture/pre-ldk/phoenix
+permalink: /guide/architecture/examples/phoenix
 main_classes: -no-top-padding
 ---
 
-{% include picture.html	
+{% include picture.html
    image = "/assets/images/architecture-phoenix.jpg"
    retina = "/assets/images/architecture-phoenix@2x.jpg"
    mobile = "/assets/images/architecture-phoenix.jpg"

--- a/bolt.fun/pages/01_guide/04_architecture/04_pre_ldk/03_phoenix.md
+++ b/bolt.fun/pages/01_guide/04_architecture/04_pre_ldk/03_phoenix.md
@@ -1,12 +1,12 @@
 ---
 layout: guide
 title: Phoenix
-parent: Architecture Examples
+parent: Mobile App Case Studies
 grand_parent: Architecture
 description: Phoenix
 nav_order: 3
 has_children: false
-permalink: /guide/architecture/examples/phoenix
+permalink: /guide/architecture/case-studies/phoenix
 main_classes: -no-top-padding
 ---
 

--- a/bolt.fun/pages/03_site-plan/00_introduction.md
+++ b/bolt.fun/pages/03_site-plan/00_introduction.md
@@ -68,7 +68,7 @@ The following is a high-level structure of how we would like to see this mini-si
 
         - Non-custodial partial node architectures
 
-          _Introduce concept of mixing and matching arichitectural pieces, and give examples of how this is done now pre-LDK_
+          _Introduce concept of mixing and matching architectural pieces, and give examples of how this is done has been done so far_
 
             \> _Outsourced routing_
 

--- a/payments/lightning-architecture.md
+++ b/payments/lightning-architecture.md
@@ -117,7 +117,7 @@ The diagram below taken from the [LDK docs](https://lightningdevkit.org/docs/#ld
 
 ---
 **_(Incomplete)_**
-## Pre-LDK Mobile App Architectures
+## Mobile App Architecture Examples
 
 **Notes to be developed:**
 - [Comprehensive wallet comparison and architecture breakdown](https://veriphi.io/en/blog/lightning-wallet-architecture)

--- a/payments/lightning-architecture.md
+++ b/payments/lightning-architecture.md
@@ -117,7 +117,7 @@ The diagram below taken from the [LDK docs](https://lightningdevkit.org/docs/#ld
 
 ---
 **_(Incomplete)_**
-## Mobile App Architecture Examples
+## Mobile App Architecture Case Studies
 
 **Notes to be developed:**
 - [Comprehensive wallet comparison and architecture breakdown](https://veriphi.io/en/blog/lightning-wallet-architecture)


### PR DESCRIPTION
## Description

The 'Pre-LDK' labels were a relic from some of our early attempts at trying to logically separate the different components of a node. This isn't a useful separation though since wallets can selectively include LDK modules now and the lines are much more blurred with respect to thinking about what the LDK is and how it could be potentially adopted.

The changes here instead recategorise the different implementations as simply "examples", and if we need to drill further into any LDK adoption/abstractions at any point then they can be done on a case-by-case basis.